### PR TITLE
Fixed Prototype Pollution bug on smart-extend

### DIFF
--- a/dist/smart-extend.js
+++ b/dist/smart-extend.js
@@ -45,6 +45,10 @@ var extend = _extend = function extend(options, target, sources, parentKey) {
 
     if (source != null) {
       for (key in source) {
+        // prototype pollution mitigation
+        if (key.includes('__proto__') || key.includes('constructor') || key.includes('prototype')) {
+          break;
+        }
         sourceValue = source[key];
         targetValue = target[key];
 


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-smart-extend

### ⚙️ Description *

smart-extend is an extension to jQuery's classic `extend()` method with additional features providing you with more power and control over your object extensions/clones.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `key` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `pwned!`.
```javascript
var extend = require('smart-extend');
var payload = '{"__proto__":{"polluted":"pwned!"}}';
var test = {};
extend.deep({},JSON.parse(payload));
console.log(test.polluted);
```

![image](https://user-images.githubusercontent.com/16708391/92280364-d8923180-ef16-11ea-9e7e-ccf13497a258.png)



### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns an error since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![image](https://user-images.githubusercontent.com/16708391/92280414-f6f82d00-ef16-11ea-8e45-934b8f124485.png)


### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `key` and no breaking changes are introduced. :)
